### PR TITLE
feat!: per-table tenant scoping with shared physical stores

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
   },
   "dependencies": {
     "@antelopejs/interface-core": "^0.0.2",
-    "@antelopejs/interface-database": "^0.0.2",
+    "@antelopejs/interface-database": "^0.1.0",
     "@antelopejs/interface-rethinkdb": "^0.0.2",
     "chai": "^4.5.0",
     "reflect-metadata": "^0.2.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^0.0.2
         version: 0.0.2
       '@antelopejs/interface-database':
-        specifier: ^0.0.2
-        version: 0.0.2
+        specifier: ^0.1.0
+        version: 0.1.0
       '@antelopejs/interface-rethinkdb':
         specifier: ^0.0.2
         version: 0.0.2
@@ -63,8 +63,11 @@ packages:
   '@antelopejs/interface-core@0.0.2':
     resolution: {integrity: sha512-CmtOJvSCRj20GOQhrE0PpHybGaW1G1lrepiKHVJa/bclhrvFYgHV0MH84TMpMOHESQT/+wuup007tfXAwaI+Eg==}
 
-  '@antelopejs/interface-database@0.0.2':
-    resolution: {integrity: sha512-SFqPwHZf1Qh1Zfcdu1CSBh5/uqT2jEczMtERcOChQYAiEKN+XwStwVttAY7yy/TKd3frqjZ3GrwKK1qXxqx7qQ==}
+  '@antelopejs/interface-core@0.0.3':
+    resolution: {integrity: sha512-Kw3ffGiQHKJ88AqdFfPuwzl+v0w6QqzqiqnLY7M0MYYw+YwdRNXh5WAJkep0ePudR9leLGXPU//FYizNaDG6yw==}
+
+  '@antelopejs/interface-database@0.1.0':
+    resolution: {integrity: sha512-6r+f5A6fttYrQyUh7NnRJxOaNjgsKpb3CeROIQGB7z5EB1vsxgOji8X3CBXflZeEIPlueMuw+YKv1e5+LE6hDg==}
 
   '@antelopejs/interface-rethinkdb@0.0.2':
     resolution: {integrity: sha512-0g2Nuyfw0AHsZ3PXrG9bVJm854aFJVhw8VVrA0tPYhYy7vFrLrsxCrhgcvqsjYlcmRRnjpwaC6lxDgwUXHHfsA==}
@@ -1177,9 +1180,13 @@ snapshots:
     dependencies:
       reflect-metadata: 0.2.2
 
-  '@antelopejs/interface-database@0.0.2':
+  '@antelopejs/interface-core@0.0.3':
     dependencies:
-      '@antelopejs/interface-core': 0.0.2
+      reflect-metadata: 0.2.2
+
+  '@antelopejs/interface-database@0.1.0':
+    dependencies:
+      '@antelopejs/interface-core': 0.0.3
 
   '@antelopejs/interface-rethinkdb@0.0.2':
     dependencies:

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -14,6 +14,7 @@ import { backtraceTerm } from "rethinkdb-ts/lib/error/term-backtrace";
 import type { TermJson } from "rethinkdb-ts/lib/internal-types";
 import { TermType } from "rethinkdb-ts/lib/proto/enums";
 import type { Cursor } from "rethinkdb-ts/lib/response/cursor";
+import { TENANT_ID_FIELD } from "./implementations/database/utils";
 import { Logger } from "./utils/logger";
 
 let connection:
@@ -102,8 +103,6 @@ export async function executeTermJson(term: TermJson): Promise<any> {
   }
   return results;
 }
-
-const TENANT_ID_FIELD = "tenant_id";
 
 export async function InitializeSchemaInPhysicalStore(
   physicalStore: string,

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -103,57 +103,18 @@ export async function executeTermJson(term: TermJson): Promise<any> {
   return results;
 }
 
-export function buildDatabaseName(
-  schemaId: string,
-  instanceId: string | undefined,
-): string {
-  return instanceId !== undefined ? `${schemaId}-${instanceId}` : schemaId;
-}
+const TENANT_ID_FIELD = "tenant_id";
 
-export async function CreateRowLevelDatabase(
-  schemaId: string,
+export async function InitializeSchemaInPhysicalStore(
+  physicalStore: string,
   schema: SchemaDefinition,
 ) {
   const dbList: string[] =
     (await executeTermJson([TermType.DB_LIST, []])) ?? [];
-  if (!dbList.includes(schemaId)) {
-    await executeTermJson([TermType.DB_CREATE, [schemaId]]);
+  if (!dbList.includes(physicalStore)) {
+    await executeTermJson([TermType.DB_CREATE, [physicalStore]]);
   }
-  await initializeDatabase(schemaId, schema, true);
-}
-
-export async function CreateSchemaInstance(
-  schemaId: string,
-  instanceId: string | undefined,
-  schema: SchemaDefinition,
-) {
-  const dbName = buildDatabaseName(schemaId, instanceId);
-  const dbList: string[] =
-    (await executeTermJson([TermType.DB_LIST, []])) ?? [];
-  if (!dbList.includes(dbName)) {
-    await executeTermJson([TermType.DB_CREATE, [dbName]]);
-  }
-  await initializeDatabase(dbName, schema);
-}
-
-export async function DestroySchemaInstance(
-  schemaId: string,
-  instanceId: string | undefined,
-) {
-  const dbName = buildDatabaseName(schemaId, instanceId);
-  const dbList: string[] =
-    (await executeTermJson([TermType.DB_LIST, []])) ?? [];
-  if (dbList.includes(dbName)) {
-    await executeTermJson([TermType.DB_DROP, [dbName]]);
-  }
-}
-
-async function initializeDatabase(
-  dbName: string,
-  schema: SchemaDefinition,
-  rowLevel?: boolean,
-) {
-  const db: TermJson = [TermType.DB, [dbName]];
+  const db: TermJson = [TermType.DB, [physicalStore]];
   const tableList: string[] =
     (await executeTermJson([TermType.TABLE_LIST, [db]])) ?? [];
 
@@ -171,7 +132,7 @@ async function initializeDatabase(
 
   await Promise.all(
     Object.entries(schema).map(([tableName, tableDef]) =>
-      initializeIndexes(db, tableName, tableDef.indexes, rowLevel),
+      initializeIndexes(db, tableName, tableDef.indexes, tableDef.tenantScoped),
     ),
   );
 }
@@ -180,7 +141,7 @@ async function initializeIndexes(
   db: TermJson,
   tableName: string,
   indexes: Record<string, any>,
-  rowLevel?: boolean,
+  tenantScoped?: boolean,
 ) {
   const table: TermJson = [TermType.TABLE, [db, tableName]];
   const existingIndexList: string[] =
@@ -221,8 +182,8 @@ async function initializeIndexes(
     }
     created = true;
   }
-  if (rowLevel && !existingIndexList.includes("tenant_id")) {
-    await executeTermJson([TermType.INDEX_CREATE, [table, "tenant_id"]]);
+  if (tenantScoped && !existingIndexList.includes(TENANT_ID_FIELD)) {
+    await executeTermJson([TermType.INDEX_CREATE, [table, TENANT_ID_FIELD]]);
     created = true;
   }
   if (created) {

--- a/src/implementations/database/expression.ts
+++ b/src/implementations/database/expression.ts
@@ -132,10 +132,6 @@ const COMPLEX_STAGE_MAP: Record<string, StageHandler> = {
     }
     return bracket;
   },
-  obj_has: (expr, fields: TermJson) => [
-    TermType.HAS_FIELDS,
-    [expr.value, ...(Array.isArray(fields) ? fields : [fields])],
-  ],
 };
 
 type FuncStageHandler = (
@@ -144,6 +140,10 @@ type FuncStageHandler = (
 ) => TermJson;
 
 const FUNC_STAGE_MAP: Record<string, FuncStageHandler> = {
+  obj_has: (expr, stage) => {
+    const fields = stage.args[0] as string[];
+    return [TermType.HAS_FIELDS, [expr.value, ...fields]];
+  },
   arr_filter: (expr, stage) => {
     const func = stage.args[0];
     const argId = allocateArgNumber();

--- a/src/implementations/database/query.ts
+++ b/src/implementations/database/query.ts
@@ -7,6 +7,7 @@ import type { Cursor } from "rethinkdb-ts/lib/response/cursor";
 import { SendQuery } from "../../connection";
 import { Logger } from "../../utils/logger";
 import { decodeExpression } from "./expression";
+import { WaitForSchemaReady } from "./schema";
 import { SelectionQuery } from "./selection";
 import { DecodingContext, type QueryStage } from "./utils";
 
@@ -116,7 +117,7 @@ export async function ReadCursor(reqId: number, stages: QueryStage[]) {
   if (!openCursors.has(reqId)) {
     const context = new DecodingContext();
     const query = SelectionQuery.decode(stages, context);
-    await query.ensureReady();
+    await WaitForSchemaReady(query.schemaId);
     const term = query.buildTerm();
     Logger.Debug("Opening cursor #", reqId);
     const cursor = await SendQuery(term);

--- a/src/implementations/database/schema.ts
+++ b/src/implementations/database/schema.ts
@@ -18,7 +18,7 @@ function ownershipKey(physicalStore: string, tableName: string): string {
   return `${physicalStore}\0${tableName}`;
 }
 
-function assertOwnership(
+function claimOwnership(
   physicalStore: string,
   tableName: string,
   schemaId: string,
@@ -33,20 +33,42 @@ function assertOwnership(
   collectionOwnership.set(key, schemaId);
 }
 
+function rollbackRegistration(
+  schemaId: string,
+  physicalStore: string,
+  claimedTables: string[],
+) {
+  for (const tableName of claimedTables) {
+    const key = ownershipKey(physicalStore, tableName);
+    if (collectionOwnership.get(key) === schemaId) {
+      collectionOwnership.delete(key);
+    }
+  }
+  delete existingSchemas[schemaId];
+  delete schemaReady[schemaId];
+}
+
 export const Schemas = {
   async register(
     schemaId: string,
     schema: SchemaDefinition,
     options: SchemaOptions,
   ) {
-    existingSchemas[schemaId] = { definition: schema, options };
     const physicalStore = options.physicalStore ?? schemaId;
-    for (const tableName of Object.keys(schema)) {
-      assertOwnership(physicalStore, tableName, schemaId);
+    existingSchemas[schemaId] = { definition: schema, options };
+    const claimed: string[] = [];
+    try {
+      for (const tableName of Object.keys(schema)) {
+        claimOwnership(physicalStore, tableName, schemaId);
+        claimed.push(tableName);
+      }
+      const ready = InitializeSchemaInPhysicalStore(physicalStore, schema);
+      schemaReady[schemaId] = ready;
+      await ready;
+    } catch (err) {
+      rollbackRegistration(schemaId, physicalStore, claimed);
+      throw err;
     }
-    const ready = InitializeSchemaInPhysicalStore(physicalStore, schema);
-    schemaReady[schemaId] = ready;
-    await ready;
   },
   unregister(schemaId: string) {
     const entry = existingSchemas[schemaId];

--- a/src/implementations/database/schema.ts
+++ b/src/implementations/database/schema.ts
@@ -33,19 +33,34 @@ function claimOwnership(
   collectionOwnership.set(key, schemaId);
 }
 
-function rollbackRegistration(
-  schemaId: string,
+function releaseOwnership(
   physicalStore: string,
-  claimedTables: string[],
+  tableNames: Iterable<string>,
+  schemaId: string,
 ) {
-  for (const tableName of claimedTables) {
+  for (const tableName of tableNames) {
     const key = ownershipKey(physicalStore, tableName);
     if (collectionOwnership.get(key) === schemaId) {
       collectionOwnership.delete(key);
     }
   }
+}
+
+function rollbackRegistration(
+  schemaId: string,
+  physicalStore: string,
+  claimedTables: string[],
+) {
+  releaseOwnership(physicalStore, claimedTables, schemaId);
   delete existingSchemas[schemaId];
   delete schemaReady[schemaId];
+}
+
+function releasePreviousClaims(schemaId: string) {
+  const previous = existingSchemas[schemaId];
+  if (!previous) return;
+  const previousStore = previous.options.physicalStore ?? schemaId;
+  releaseOwnership(previousStore, Object.keys(previous.definition), schemaId);
 }
 
 export const Schemas = {
@@ -55,6 +70,7 @@ export const Schemas = {
     options: SchemaOptions,
   ) {
     const physicalStore = options.physicalStore ?? schemaId;
+    releasePreviousClaims(schemaId);
     existingSchemas[schemaId] = { definition: schema, options };
     const claimed: string[] = [];
     try {
@@ -74,12 +90,7 @@ export const Schemas = {
     const entry = existingSchemas[schemaId];
     if (entry) {
       const physicalStore = entry.options.physicalStore ?? schemaId;
-      for (const tableName of Object.keys(entry.definition)) {
-        const key = ownershipKey(physicalStore, tableName);
-        if (collectionOwnership.get(key) === schemaId) {
-          collectionOwnership.delete(key);
-        }
-      }
+      releaseOwnership(physicalStore, Object.keys(entry.definition), schemaId);
     }
     delete existingSchemas[schemaId];
     delete schemaReady[schemaId];

--- a/src/implementations/database/schema.ts
+++ b/src/implementations/database/schema.ts
@@ -3,17 +3,35 @@ import type {
   SchemaDefinition,
   SchemaOptions,
 } from "@antelopejs/interface-database/schema";
-import {
-  CreateRowLevelDatabase,
-  CreateSchemaInstance,
-  DestroySchemaInstance,
-} from "../../connection";
+import { InitializeSchemaInPhysicalStore } from "../../connection";
 
-export const existingSchemas: Record<
+const existingSchemas: Record<
   string,
   { definition: SchemaDefinition; options: SchemaOptions }
 > = {};
-export const existingInstances: Record<string, Set<string>> = {};
+
+const schemaReady: Record<string, Promise<void>> = {};
+
+const collectionOwnership = new Map<string, string>();
+
+function ownershipKey(physicalStore: string, tableName: string): string {
+  return `${physicalStore}\0${tableName}`;
+}
+
+function assertOwnership(
+  physicalStore: string,
+  tableName: string,
+  schemaId: string,
+) {
+  const key = ownershipKey(physicalStore, tableName);
+  const owner = collectionOwnership.get(key);
+  if (owner && owner !== schemaId) {
+    throw new Error(
+      `Table '${tableName}' in physical store '${physicalStore}' is already declared by schema '${owner}', cannot redeclare in '${schemaId}'`,
+    );
+  }
+  collectionOwnership.set(key, schemaId);
+}
 
 export const Schemas = {
   async register(
@@ -22,22 +40,37 @@ export const Schemas = {
     options: SchemaOptions,
   ) {
     existingSchemas[schemaId] = { definition: schema, options };
-    if (!existingInstances[schemaId]) {
-      existingInstances[schemaId] = new Set<string>();
+    const physicalStore = options.physicalStore ?? schemaId;
+    for (const tableName of Object.keys(schema)) {
+      assertOwnership(physicalStore, tableName, schemaId);
     }
-    if (!options.rowLevel) {
-      return;
-    }
-    await CreateRowLevelDatabase(schemaId, schema);
+    const ready = InitializeSchemaInPhysicalStore(physicalStore, schema);
+    schemaReady[schemaId] = ready;
+    await ready;
   },
   unregister(schemaId: string) {
+    const entry = existingSchemas[schemaId];
+    if (entry) {
+      const physicalStore = entry.options.physicalStore ?? schemaId;
+      for (const tableName of Object.keys(entry.definition)) {
+        const key = ownershipKey(physicalStore, tableName);
+        if (collectionOwnership.get(key) === schemaId) {
+          collectionOwnership.delete(key);
+        }
+      }
+    }
     delete existingSchemas[schemaId];
-    delete existingInstances[schemaId];
+    delete schemaReady[schemaId];
   },
 };
 
-export function IsRowLevel(schemaId: string): boolean {
-  return existingSchemas[schemaId]?.options?.rowLevel === true;
+export function WaitForSchemaReady(schemaId: string): Promise<void> {
+  return schemaReady[schemaId] ?? Promise.resolve();
+}
+
+export function GetPhysicalStore(schemaId: string): string {
+  assert(schemaId in existingSchemas, `Unknown schema '${schemaId}'`);
+  return existingSchemas[schemaId].options.physicalStore ?? schemaId;
 }
 
 export function GetSchema(schemaId: string) {
@@ -49,6 +82,10 @@ export function GetTable(schemaId: string, tableId: string) {
   const schema = GetSchema(schemaId);
   assert(tableId in schema);
   return schema[tableId];
+}
+
+export function IsTenantScoped(schemaId: string, tableId: string): boolean {
+  return GetTable(schemaId, tableId).tenantScoped === true;
 }
 
 export function HasIndex(
@@ -72,46 +109,4 @@ export function GetIndex(
   }
   assert(!onlyIndex);
   return { fields: [indexId] };
-}
-
-export function IsValidInstance(
-  schemaId: string,
-  instanceId: string | undefined,
-) {
-  assert(schemaId in existingInstances);
-  if (IsRowLevel(schemaId)) {
-    if (instanceId === undefined) {
-      throw new Error(`Row-level schema '${schemaId}' requires a tenant ID`);
-    }
-    return true;
-  }
-  return existingInstances[schemaId].has(instanceId ?? "");
-}
-
-export async function CreateInstance(
-  schemaId: string,
-  instanceId: string | undefined,
-) {
-  if (IsRowLevel(schemaId)) {
-    return;
-  }
-  const schema = GetSchema(schemaId);
-  existingInstances[schemaId].add(instanceId ?? "");
-  await CreateSchemaInstance(schemaId, instanceId, schema);
-}
-
-export async function DestroyInstance(
-  schemaId: string,
-  instanceId: string | undefined,
-) {
-  if (IsRowLevel(schemaId)) {
-    return;
-  }
-  assert(schemaId in existingInstances);
-  const instances = existingInstances[schemaId];
-  const key = instanceId ?? "";
-  if (instances.has(key)) {
-    instances.delete(key);
-  }
-  await DestroySchemaInstance(schemaId, instanceId);
 }

--- a/src/implementations/database/selection.ts
+++ b/src/implementations/database/selection.ts
@@ -1,14 +1,9 @@
 import assert from "node:assert";
+import { CROSS_TENANT } from "@antelopejs/interface-database/schema";
 import type { TermJson } from "rethinkdb-ts/lib/internal-types";
 import { TermType } from "rethinkdb-ts/lib/proto/enums";
-import { buildDatabaseName } from "../../connection";
 import { DecodeFunction, DecodeValue, executeTermJson } from "./query";
-import {
-  CreateInstance,
-  DestroyInstance,
-  IsRowLevel,
-  IsValidInstance,
-} from "./schema";
+import { GetPhysicalStore, IsTenantScoped, WaitForSchemaReady } from "./schema";
 import { applyStreamStages } from "./stream";
 import { allocateArgNumber, DecodingContext, type QueryStage } from "./utils";
 
@@ -19,9 +14,12 @@ type ResultType =
   | "insert"
   | "update"
   | "replace"
-  | "delete"
-  | "createInstance"
-  | "destroyInstance";
+  | "delete";
+
+type TenantContext =
+  | { kind: "none" }
+  | { kind: "scoped"; tenantId: string }
+  | { kind: "cross" };
 
 const WRITE_STAGES = new Set(["insert", "update", "replace", "delete"]);
 const PRE_STREAM_STAGES = new Set([
@@ -34,6 +32,30 @@ const PRE_STREAM_STAGES = new Set([
   "delete",
 ]);
 
+function resolveTenantContext(
+  schemaId: string,
+  tableName: string,
+  instanceId: unknown,
+): TenantContext {
+  if (!IsTenantScoped(schemaId, tableName)) {
+    return { kind: "none" };
+  }
+  if (instanceId === undefined) {
+    throw new Error(
+      `Table '${tableName}' is tenant-scoped: a tenant id must be provided via Schema.instance(...)`,
+    );
+  }
+  if (instanceId === CROSS_TENANT) {
+    return { kind: "cross" };
+  }
+  if (typeof instanceId !== "string") {
+    throw new Error(
+      `Invalid tenant id for table '${tableName}': expected string or CROSS_TENANT, got ${typeof instanceId}`,
+    );
+  }
+  return { kind: "scoped", tenantId: instanceId };
+}
+
 export class SelectionQuery {
   public resultType: ResultType = "table";
   public isChangeStream = false;
@@ -42,24 +64,21 @@ export class SelectionQuery {
   private conflictMode?: "update" | "replace";
   private insertRawArgs?: any;
   private term: TermJson;
-  private readonly rowLevel: boolean;
+  private readonly tenant: TenantContext;
 
   public constructor(
     public readonly schemaId: string,
-    public readonly instanceId: string | undefined,
+    public readonly instanceId: string | typeof CROSS_TENANT | undefined,
     public readonly tableName: string,
     public readonly database: string,
     private context: DecodingContext,
   ) {
-    this.rowLevel = IsRowLevel(schemaId);
+    this.tenant = resolveTenantContext(schemaId, tableName, instanceId);
     const baseTerm: TermJson = [
       TermType.TABLE,
       [[TermType.DB, [database]], tableName],
     ];
-    if (this.rowLevel) {
-      if (instanceId === undefined) {
-        throw new Error(`Row-level schema '${schemaId}' requires a tenant ID`);
-      }
+    if (this.tenant.kind === "scoped") {
       this.term = this.buildTenantFilterTerm(baseTerm);
     } else {
       this.term = baseTerm;
@@ -82,41 +101,11 @@ export class SelectionQuery {
     const schemaId = stages[0].options?.id;
     assert(schemaId, "Unknown schema");
 
-    if (stages[1]?.stage === "createInstance") {
-      const instanceId = stages[1].options?.id;
-      const database = buildDatabaseName(schemaId, instanceId);
-      const query = new SelectionQuery(
-        schemaId,
-        instanceId,
-        "",
-        database,
-        context,
-      );
-      query.resultType = "createInstance";
-      return query;
-    }
-
-    if (stages[1]?.stage === "destroyInstance") {
-      const instanceId = stages[1].options?.id;
-      const database = buildDatabaseName(schemaId, instanceId);
-      const query = new SelectionQuery(
-        schemaId,
-        instanceId,
-        "",
-        database,
-        context,
-      );
-      query.resultType = "destroyInstance";
-      return query;
-    }
-
     assert(stages[1]?.stage === "instance", "Expected instance stage");
     const instanceId = stages[1].options?.id;
     assert(stages[2]?.stage === "table", "Expected table stage");
     const tableName = stages[2].options.id;
-    const database = IsRowLevel(schemaId)
-      ? schemaId
-      : buildDatabaseName(schemaId, instanceId);
+    const database = GetPhysicalStore(schemaId);
 
     const query = new SelectionQuery(
       schemaId,
@@ -185,16 +174,8 @@ export class SelectionQuery {
   }
 
   public async run(): Promise<any> {
-    if (
-      this.resultType !== "createInstance" &&
-      this.resultType !== "destroyInstance"
-    ) {
-      await this.ensureInstance();
-    }
-
+    await WaitForSchemaReady(this.schemaId);
     const RUN_HANDLERS: Record<string, () => Promise<any>> = {
-      createInstance: () => this.runCreateInstance(),
-      destroyInstance: () => this.runDestroyInstance(),
       insert: () => this.runInsert(),
       update: () => this.runUpdate(),
       replace: () => this.runReplace(),
@@ -213,37 +194,15 @@ export class SelectionQuery {
     return result;
   }
 
-  public async ensureReady() {
-    await this.ensureInstance();
-  }
-
-  private async ensureInstance() {
-    if (!IsValidInstance(this.schemaId, this.instanceId)) {
+  private async runInsert() {
+    if (this.tenant.kind === "cross") {
       throw new Error(
-        `Instance '${this.instanceId ?? "(global)"}' does not exist for schema '${this.schemaId}'`,
+        `Insert into tenant-scoped table '${this.tableName}' requires a specific tenant id (CROSS_TENANT is read-only)`,
       );
     }
-  }
-
-  private async runCreateInstance() {
-    if (this.rowLevel) {
-      return this.instanceId;
-    }
-    await CreateInstance(this.schemaId, this.instanceId);
-    return this.instanceId;
-  }
-
-  private async runDestroyInstance() {
-    if (this.rowLevel) {
-      return;
-    }
-    await DestroyInstance(this.schemaId, this.instanceId);
-  }
-
-  private async runInsert() {
     let value = this.newValue;
-    if (this.rowLevel && this.instanceId !== undefined) {
-      value = this.stampTenantId(value);
+    if (this.tenant.kind === "scoped") {
+      value = this.stampTenantId(value, this.tenant.tenantId);
     }
     const insertOpts = this.conflictMode ? { conflict: this.conflictMode } : {};
     const insertTerm: TermJson = [
@@ -268,15 +227,15 @@ export class SelectionQuery {
     );
   }
 
-  private stampTenantId(value: any): any {
+  private stampTenantId(value: any, tenantId: string): any {
     if (Array.isArray(value) && value[0] === TermType.MAKE_ARRAY) {
       return [
         TermType.MAKE_ARRAY,
-        value[1].map((doc: any) => this.stampTenantId(doc)),
+        value[1].map((doc: any) => this.stampTenantId(doc, tenantId)),
       ];
     }
     if (value && typeof value === "object" && !Array.isArray(value)) {
-      return { ...value, tenant_id: this.instanceId };
+      return { ...value, tenant_id: tenantId };
     }
     return value;
   }
@@ -286,6 +245,8 @@ export class SelectionQuery {
   }
 
   public buildTenantFilterTerm(baseTerm: TermJson): TermJson {
+    assert(this.tenant.kind === "scoped");
+    const tenantId = this.tenant.tenantId;
     const argId = allocateArgNumber();
     const filterFn: TermJson = [
       TermType.FUNC,
@@ -295,7 +256,7 @@ export class SelectionQuery {
           TermType.EQ,
           [
             [TermType.BRACKET, [[TermType.VAR, [argId]], "tenant_id"]],
-            this.instanceId,
+            tenantId,
           ],
         ],
       ],
@@ -303,14 +264,13 @@ export class SelectionQuery {
     return [TermType.FILTER, [baseTerm, filterFn]];
   }
 
-  public isRowLevel(): boolean {
-    return this.rowLevel;
+  public hasTenantFilter(): boolean {
+    return this.tenant.kind === "scoped";
   }
 
   public isSimpleTable(): boolean {
-    // TODO: This is really just a patch to avoid putting a GET_ALL after other operations, we should have a way to insert the get all "deeper" in the term
     return (
-      !this.isRowLevel() &&
+      !this.hasTenantFilter() &&
       Array.isArray(this.term) &&
       this.term[0] === TermType.TABLE
     );
@@ -330,8 +290,8 @@ export class SelectionQuery {
     const argId = allocateArgNumber();
     const oldDoc: TermJson = [TermType.VAR, [argId]];
     let replaceValue = this.newValue;
-    if (this.rowLevel && this.instanceId !== undefined) {
-      replaceValue = { ...replaceValue, tenant_id: this.instanceId };
+    if (this.tenant.kind === "scoped") {
+      replaceValue = { ...replaceValue, tenant_id: this.tenant.tenantId };
     }
     const merged: TermJson = [
       TermType.MERGE,
@@ -375,7 +335,7 @@ const SELECTION_STAGES: Record<string, SelectionStageHandler> = {
   get: (query, stage) => {
     query.resultType = "selection";
     query.singleElement = true;
-    const tableTerm = query.isRowLevel()
+    const tableTerm = query.hasTenantFilter()
       ? query.getTableTerm()
       : query.buildTerm();
     const key = DecodeValue(stage.args[0], query.getContext());
@@ -383,7 +343,7 @@ const SELECTION_STAGES: Record<string, SelectionStageHandler> = {
   },
   getAll: (query, stage) => {
     query.resultType = "selection";
-    const baseTerm = query.isRowLevel()
+    const baseTerm = query.hasTenantFilter()
       ? query.getTableTerm()
       : query.buildTerm();
     const index = stage.options?.index;
@@ -398,12 +358,12 @@ const SELECTION_STAGES: Record<string, SelectionStageHandler> = {
       index ? { index } : {},
     ];
     query.setTerm(
-      query.isRowLevel() ? query.buildTenantFilterTerm(term) : term,
+      query.hasTenantFilter() ? query.buildTenantFilterTerm(term) : term,
     );
   },
   between: (query, stage) => {
     query.resultType = "selection";
-    const baseTerm = query.isRowLevel()
+    const baseTerm = query.hasTenantFilter()
       ? query.getTableTerm()
       : query.buildTerm();
     const index = stage.options?.index;
@@ -415,7 +375,7 @@ const SELECTION_STAGES: Record<string, SelectionStageHandler> = {
       index ? { index } : {},
     ];
     query.setTerm(
-      query.isRowLevel() ? query.buildTenantFilterTerm(term) : term,
+      query.hasTenantFilter() ? query.buildTenantFilterTerm(term) : term,
     );
   },
   insert: (query, stage) => {

--- a/src/implementations/database/selection.ts
+++ b/src/implementations/database/selection.ts
@@ -5,7 +5,12 @@ import { TermType } from "rethinkdb-ts/lib/proto/enums";
 import { DecodeFunction, DecodeValue, executeTermJson } from "./query";
 import { GetPhysicalStore, IsTenantScoped, WaitForSchemaReady } from "./schema";
 import { applyStreamStages } from "./stream";
-import { allocateArgNumber, DecodingContext, type QueryStage } from "./utils";
+import {
+  allocateArgNumber,
+  DecodingContext,
+  type QueryStage,
+  TENANT_ID_FIELD,
+} from "./utils";
 
 type ResultType =
   | "stream"
@@ -235,7 +240,7 @@ export class SelectionQuery {
       ];
     }
     if (value && typeof value === "object" && !Array.isArray(value)) {
-      return { ...value, tenant_id: tenantId };
+      return { ...value, [TENANT_ID_FIELD]: tenantId };
     }
     return value;
   }
@@ -255,7 +260,7 @@ export class SelectionQuery {
         [
           TermType.EQ,
           [
-            [TermType.BRACKET, [[TermType.VAR, [argId]], "tenant_id"]],
+            [TermType.BRACKET, [[TermType.VAR, [argId]], TENANT_ID_FIELD]],
             tenantId,
           ],
         ],
@@ -296,7 +301,10 @@ export class SelectionQuery {
     const oldDoc: TermJson = [TermType.VAR, [argId]];
     let replaceValue = this.newValue;
     if (this.tenant.kind === "scoped") {
-      replaceValue = { ...replaceValue, tenant_id: this.tenant.tenantId };
+      replaceValue = {
+        ...replaceValue,
+        [TENANT_ID_FIELD]: this.tenant.tenantId,
+      };
     }
     const merged: TermJson = [
       TermType.MERGE,

--- a/src/implementations/database/selection.ts
+++ b/src/implementations/database/selection.ts
@@ -287,6 +287,11 @@ export class SelectionQuery {
   }
 
   private async runReplace() {
+    if (this.tenant.kind === "cross") {
+      throw new Error(
+        `Replace on tenant-scoped table '${this.tableName}' requires a specific tenant id (CROSS_TENANT would silently strip the tenant_id from the replaced document; use update for cross-tenant mutations)`,
+      );
+    }
     const argId = allocateArgNumber();
     const oldDoc: TermJson = [TermType.VAR, [argId]];
     let replaceValue = this.newValue;

--- a/src/implementations/database/stream.ts
+++ b/src/implementations/database/stream.ts
@@ -2,7 +2,7 @@ import type { Stream } from "@antelopejs/interface-database";
 import type { TermJson } from "rethinkdb-ts/lib/internal-types";
 import { TermType } from "rethinkdb-ts/lib/proto/enums";
 import { DecodeFunction, DecodeValue } from "./query";
-import { GetIndex, HasIndex, IsRowLevel } from "./schema";
+import { GetIndex, HasIndex } from "./schema";
 import { SelectionQuery } from "./selection";
 import {
   allocateArgNumber,
@@ -421,32 +421,34 @@ function handleNth(
   return [TermType.NTH, [prev, n]];
 }
 
+function buildMappedDistinct(prev: TermJson, field: string): TermJson {
+  const argId = allocateArgNumber();
+  const mapped: TermJson = [
+    TermType.MAP,
+    [
+      prev,
+      [
+        TermType.FUNC,
+        [
+          [TermType.MAKE_ARRAY, [argId]],
+          [TermType.BRACKET, [[TermType.VAR, [argId]], field]],
+        ],
+      ],
+    ],
+  ];
+  return [TermType.DISTINCT, [mapped]];
+}
+
 function handleCount(
   prev: TermJson,
   stage: QueryStage,
   _context: DecodingContext,
-  schemaId: string,
+  _schemaId: string,
+  _tableName: string,
 ): TermJson {
   if (stage.options?.field) {
-    if (IsRowLevel(schemaId)) {
-      const argId = allocateArgNumber();
-      const mapped: TermJson = [
-        TermType.MAP,
-        [
-          prev,
-          [
-            TermType.FUNC,
-            [
-              [TermType.MAKE_ARRAY, [argId]],
-              [
-                TermType.BRACKET,
-                [[TermType.VAR, [argId]], stage.options.field],
-              ],
-            ],
-          ],
-        ],
-      ];
-      return [TermType.COUNT, [[TermType.DISTINCT, [mapped]]]];
+    if (!isTableTerm(prev)) {
+      return [TermType.COUNT, [buildMappedDistinct(prev, stage.options.field)]];
     }
     return [
       TermType.COUNT,
@@ -490,28 +492,12 @@ function handleDistinct(
   prev: TermJson,
   stage: QueryStage,
   _context: DecodingContext,
-  schemaId: string,
+  _schemaId: string,
+  _tableName: string,
 ): TermJson {
   if (stage.options?.field) {
-    if (IsRowLevel(schemaId)) {
-      const argId = allocateArgNumber();
-      const mapped: TermJson = [
-        TermType.MAP,
-        [
-          prev,
-          [
-            TermType.FUNC,
-            [
-              [TermType.MAKE_ARRAY, [argId]],
-              [
-                TermType.BRACKET,
-                [[TermType.VAR, [argId]], stage.options.field],
-              ],
-            ],
-          ],
-        ],
-      ];
-      return [TermType.DISTINCT, [mapped]];
+    if (!isTableTerm(prev)) {
+      return buildMappedDistinct(prev, stage.options.field);
     }
     return [TermType.DISTINCT, [prev], { index: stage.options.field }];
   }

--- a/src/implementations/database/utils.ts
+++ b/src/implementations/database/utils.ts
@@ -1,5 +1,7 @@
 import type { StagedObject } from "@antelopejs/interface-database/common";
 
+export const TENANT_ID_FIELD = "tenant_id";
+
 export type QueryStage = StagedObject["stages"][number];
 
 export type ArgumentProvider = (subQuery: QueryStage[]) => any;


### PR DESCRIPTION
## Summary
- Aligns the implementation with `@antelopejs/interface-database@0.1.0`: schemas now declare a `physicalStore` (shared across schemas) and tenant scoping is per-table via `tenantScoped`, instead of the old per-schema `rowLevel` flag and per-instance databases.
- Removes the explicit `createInstance` / `destroyInstance` lifecycle in favor of lazy, implicit initialization (`WaitForSchemaReady`) and adds `CROSS_TENANT` read support so a query can span all tenants of a tenant-scoped table (writes still require a concrete tenant id).
- Tightens internals: collection-ownership guard so two schemas cannot redeclare the same table in a shared store, `obj_has` moved to the function-stage map, and `count`/`distinct` by-field switch from `IsRowLevel` to a structural `isTableTerm` check.

## Breaking changes
- Removes `CreateRowLevelDatabase`, `CreateSchemaInstance`, `DestroySchemaInstance`, `buildDatabaseName`, `IsRowLevel`, `IsValidInstance`, `CreateInstance`, `DestroyInstance`, and the `createInstance` / `destroyInstance` query stages.
- `SchemaOptions.rowLevel` is replaced by `SchemaOptions.physicalStore` and `TableDefinition.tenantScoped`.

## Test plan
- [ ] `pnpm install` resolves `@antelopejs/interface-database@^0.1.0`
- [ ] `pnpm build` / typecheck passes
- [ ] `pnpm test` — full suite, with focus on:
  - [ ] non-tenant tables still read/write without an instance
  - [ ] tenant-scoped tables stamp `tenant_id` on insert and filter on read
  - [ ] tenant-scoped tables reject inserts when `instanceId` is `CROSS_TENANT`
  - [ ] `CROSS_TENANT` reads return rows across all tenants
  - [ ] two schemas sharing a `physicalStore` cannot redeclare the same table
  - [ ] `count` / `distinct` by field still work on both raw tables and post-filter streams

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR refactors the RethinkDB adapter to align with `@antelopejs/interface-database@0.1.0`, replacing per-schema `rowLevel`/`createInstance`/`destroyInstance` lifecycle with per-table `tenantScoped` flags and a shared `physicalStore`, and adding `CROSS_TENANT` read support.

- `Schemas.register` now lazily initializes the physical store via `InitializeSchemaInPhysicalStore`, stores a `schemaReady` promise, and enforces a `collectionOwnership` guard so two schemas cannot redeclare the same table in the same store.
- `SelectionQuery` replaces the `rowLevel` boolean with a typed `TenantContext` union (`none` | `scoped` | `cross`), correctly applying tenant filters only for `scoped` queries and guarding `insert` and `replace` against `CROSS_TENANT` instances; `runUpdate` and `runDelete` do not yet have equivalent guards.
- `count`/`distinct` by-field now branches on `isTableTerm(prev)` instead of `IsRowLevel(schemaId)`, which correctly handles post-filter streams for all table types.

<h3>Confidence Score: 3/5</h3>

Not ready to merge: CROSS_TENANT write guards are missing for update and delete on tenant-scoped tables, which would silently mutate or wipe data across all tenants.

The `runUpdate` and `runDelete` methods execute directly against `this.term`, which for a CROSS_TENANT instance is the raw TABLE term with no tenant filter applied. A CROSS_TENANT `.update()` or `.delete()` would touch every row in the table across all tenants. `runInsert` and `runReplace` gained the correct guard in this PR, but the same protection is absent for the remaining two write paths.

src/implementations/database/selection.ts — `runUpdate` (line 288) and `runDelete` (line 322) need CROSS_TENANT guards matching the one added to `runInsert` and `runReplace`.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/implementations/database/selection.ts | Core query execution; `runInsert` and `runReplace` gain CROSS_TENANT guards, but `runUpdate` and `runDelete` remain unguarded — a CROSS_TENANT update/delete would silently operate across the entire tenant-scoped table. |
| src/implementations/database/schema.ts | New ownership guard and lazy-init pattern; `existingSchemas` is written before ownership is validated, creating a window where the schema is visible but partially claimed. |
| src/implementations/database/stream.ts | Extracts `buildMappedDistinct` helper and switches `count`/`distinct` by-field branch from `IsRowLevel` to structural `isTableTerm`; no regressions found. |
| src/implementations/database/expression.ts | Moves `obj_has` from COMPLEX_STAGE_MAP to FUNC_STAGE_MAP; field args are now read as raw `stage.args[0]` without `DecodeValue`, which could mishandle non-string field proxies. |
| src/connection.ts | Removes per-instance database lifecycle helpers; `InitializeSchemaInPhysicalStore` now filters tables by `tenantScoped` for index creation; straightforward and correct. |
| src/implementations/database/utils.ts | Adds `TENANT_ID_FIELD` constant to centralise the field name; no issues. |
| src/implementations/database/query.ts | Switches `ReadCursor` to `WaitForSchemaReady(query.schemaId)`, appropriate for the new lazy-init model. |

</details>


</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/implementations/database/selection.ts`, line 283-312 ([link](https://github.com/antelopejs/rethinkdb/blob/31230157fe5b77218f5a89acc4f64885072f90e6/src/implementations/database/selection.ts#L283-L312)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **CROSS_TENANT writes unguarded for update, replace, and delete**

   `runInsert` correctly rejects a `CROSS_TENANT` instance, but `runUpdate`, `runReplace`, and `runDelete` have no equivalent guard. When `tenant.kind === "cross"`, `this.term` is the raw TABLE term with no tenant filter applied. An update, replace, or delete call via a CROSS_TENANT instance would silently operate across every tenant row in the table — a `.delete()` would wipe the entire table. The PR description explicitly states "writes still require a concrete tenant id."

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/implementations/database/selection.ts
   Line: 283-312

   Comment:
   **CROSS_TENANT writes unguarded for update, replace, and delete**

   `runInsert` correctly rejects a `CROSS_TENANT` instance, but `runUpdate`, `runReplace`, and `runDelete` have no equivalent guard. When `tenant.kind === "cross"`, `this.term` is the raw TABLE term with no tenant filter applied. An update, replace, or delete call via a CROSS_TENANT instance would silently operate across every tenant row in the table — a `.delete()` would wipe the entire table. The PR description explicitly states "writes still require a concrete tenant id."

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
src/implementations/database/schema.ts:74-87
**Schema entry written before ownership is fully validated**

`existingSchemas[schemaId]` is overwritten at line 74, before the ownership loop completes. If `claimOwnership` succeeds for table N and then throws on table N+1 (because another schema already owns it), `rollbackRegistration` will correctly release the N claimed tables and delete the entry. However, between line 74 and the first `await` in the try block, any concurrent read via `GetPhysicalStore(schemaId)` or `IsTenantScoped(schemaId, ...)` will observe the new (partially-valid) definition while ownership is still in progress. Moving the write into the try block after all claims are verified would close this window.


`````

</details>

<sub>Reviews (4): Last reviewed commit: ["fix: release stale ownership claims when..."](https://github.com/antelopejs/rethinkdb/commit/c1ed3b935ca7af2b3fa3875556d25e2b59eec47e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31492657)</sub>

<!-- /greptile_comment -->